### PR TITLE
Fallback to setting rails_env as server if no server host is found.

### DIFF
--- a/lib/codebase/recipes.rb
+++ b/lib/codebase/recipes.rb
@@ -21,7 +21,7 @@ Capistrano::Configuration.instance(:must_exist).load do
         set :environment, rails_env
       end
       
-      cmd << "-s #{roles.values.collect{|r| r.servers}.flatten.collect{|s| s.host}.uniq.join(',') rescue ''}"
+      cmd << "-s #{roles.values.collect{|r| r.servers}.flatten.collect{|s| s.host}.uniq.join(',') rescue fetch(:rails_env)}"
       cmd << "-b #{branch}"
       cmd << "-e #{environment}" if respond_to?(:environment)
       


### PR DESCRIPTION
Return rails_env if no host is found, instead of failing to send request because no server is set.
